### PR TITLE
on exit code, log path of file returning code rather than plugin.name

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(options) {
       var error;
 
       if (code && 65 !== code) {
-        error = new gutil.PluginError(plugin.name, plugin.name + ': returned ' + code);
+        error = new gutil.PluginError(plugin.name, file.path + ': returned ' + code);
       }
 
       cb(error, file);


### PR DESCRIPTION
Hi @oskarjakiela -- I thought that this small change might address issue #3. If there is an exit code, I think that it's clearer to log the path of the file returning the exit code rather than simple repeating the name of the plugin. What do you think?
